### PR TITLE
Fix typo in forward_compatible_horizon function signature

### DIFF
--- a/tensorflow/python/compat/compat.py
+++ b/tensorflow/python/compat/compat.py
@@ -134,7 +134,7 @@ def forward_compatibility_horizon(year, month, day):
   with older binaries, new features can be gated with:
 
   ```python
-  if compat.forward_compatible(year=2018, month=08, date=01):
+  if compat.forward_compatible(year=2018, month=08, day=01):
     generate_graph_with_new_features()
   else:
     generate_graph_so_older_binaries_can_consume_it()


### PR DESCRIPTION
**Pull Request Summary:**

This pull request updates the forward compatibility date in the `forward_compatibility_horizon` function to fix a small typo in the function signature. The parameter name `date` has been corrected to `day` for consistency.

**Changes Made:**
- Updated the function signature in `forward_compatibility_horizon` from `forward_compatible(year=2018, month=08, date=01)` to `forward_compatible(year=2018, month=08, day=01)`.

This change is cosmetic and does not alter the functionality of the code. It enhances code readability by aligning the parameter name with its usage within the function.

**Context:**
The adjustment aims to maintain a uniform and intuitive coding style. Consistent parameter naming conventions contribute to a more understandable codebase and facilitate collaboration among contributors. This modification has no impact on the behavior of the code but promotes better code comprehension.



```diff
- if compat.forward_compatible(year=2018, month=08, date=01):
+ if compat.forward_compatible(year=2018, month=08, day=01):
